### PR TITLE
Bias semi structured sparse

### DIFF
--- a/examples/offline_inference_semi_structured_sparse.py
+++ b/examples/offline_inference_semi_structured_sparse.py
@@ -1,6 +1,6 @@
 from vllm import LLM, SamplingParams
 
-model = LLM("nm-testing/zephyr-50sparse-24",
+model = LLM("nm-testing/opt-125m-pruned2.4",
             sparsity="semi_structured_sparse_w16a16",
             enforce_eager=True,
             dtype="float16",


### PR DESCRIPTION
SUMMARY:
- 2:4 semi-structured sparsity handles non-None bias

TEST:
- examples/offline_inference_semi_structured_sparse.py
- nm-testing/opt-125m-pruned2.4