### PR TITLE
Add bias support for sparse layers

### DIFF
--- a/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
@@ -75,16 +75,20 @@ class SparseW16A16LinearMethod(LinearMethodBase):
             reshaped_x, valid_rows_range = pad_tensor_to_multiple(
                 x.reshape(-1, x.shape[-1]), 8
             )
+            if bias is None:
+                bias = torch.nn.Parameter(
+                    torch.zeros(
+                        (w_encap.shape[0],),
+                        dtype=reshaped_x.dtype,
+                        device=reshaped_x.device,
+                    )
+                )
             output = F.linear(
                 reshaped_x,
                 w_encap,
-                torch.nn.Parameter(torch.zeros((w_encap.shape[0],)))
-                .to(reshaped_x.dtype)
-                .to(reshaped_x.device),
+                bias,
             ).contiguous()
             output = extract_valid_rows(output, valid_rows_range).reshape(out_shape)
-            if bias is not None:
-                output = output + bias
         elif self.storage_format_cls == SparseBEGemmStorageFormat:
             assert w.compress_transposed
             out_shape = x.shape[:-1] + (w.shape[0],)

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
@@ -65,22 +65,23 @@ class SparseW16A16LinearMethod(LinearMethodBase):
             if bias is None:
                 bias = torch.nn.Parameter(
                     torch.zeros(
-                        (w_encap.shape[0],),
+                        (w_encap.shape[0], ),
                         dtype=reshaped_x.dtype,
                         device=reshaped_x.device,
-                    )
-                )
+                    ))
             output = F.linear(
                 reshaped_x,
                 w_encap,
                 bias,
             ).contiguous()
-            output = extract_valid_rows(output, valid_rows_range).reshape(out_shape)
+            output = extract_valid_rows(output,
+                                        valid_rows_range).reshape(out_shape)
         elif self.storage_format_cls == SparseBEGemmStorageFormat:
             assert w.compress_transposed
             out_shape = (x.shape[:-1] + (w.shape[0], ))
             reshaped_x = x.reshape(-1, x.shape[-1])
-            output = be_ds_gemm(reshaped_x, w.compressed_data).reshape(out_shape)
+            output = be_ds_gemm(reshaped_x,
+                                w.compressed_data).reshape(out_shape)
             if bias is not None:
                 output = output + bias
         else:

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py
@@ -6,10 +6,12 @@ import torch.nn.functional as F
 from vllm.model_executor.layers.linear import LinearMethodBase, set_weight_attrs
 from vllm.model_executor.layers.sparsity.base_config import SparsityConfig
 from vllm.model_executor.layers.parameters import LazyCompressedParameter
-from magic_wand.semi_structured import (pad_tensor_to_multiple,
-                                        extract_valid_rows)
-from magic_wand import (CompressedStorageFormat, SparseBEGemmStorageFormat,
-                        SparseSemiStructuredStorageFormat)
+from magic_wand.semi_structured import pad_tensor_to_multiple, extract_valid_rows
+from magic_wand import (
+    CompressedStorageFormat,
+    SparseBEGemmStorageFormat,
+    SparseSemiStructuredStorageFormat,
+)
 from magic_wand.ops import be_ds_gemm
 
 
@@ -19,26 +21,36 @@ class SparseW16A16LinearMethod(LinearMethodBase):
     Args:
         sparsity_config: The sparse config.
     """
+
     storage_format_cls: Type[CompressedStorageFormat] = None
 
-    def __init__(self, sparsity_config: SparsityConfig,
-                 storage_format_cls: Type[CompressedStorageFormat]):
+    def __init__(
+        self,
+        sparsity_config: SparsityConfig,
+        storage_format_cls: Type[CompressedStorageFormat],
+    ):
         self.sparsity_config = sparsity_config
         self.storage_format_cls = storage_format_cls
 
-    def create_weights(self, input_size_per_partition: int,
-                       output_size_per_partition: int, input_size: int,
-                       output_size: int,
-                       params_dtype: torch.dtype) -> Dict[str, Any]:
-        supports_linear = (self.storage_format_cls !=
-                           SparseBEGemmStorageFormat)
+    def create_weights(
+        self,
+        input_size_per_partition: int,
+        output_size_per_partition: int,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> Dict[str, Any]:
+        supports_linear = self.storage_format_cls != SparseBEGemmStorageFormat
         weight = LazyCompressedParameter(
-            torch.empty((output_size_per_partition, input_size_per_partition),
-                        dtype=params_dtype),
+            torch.empty(
+                (output_size_per_partition, input_size_per_partition),
+                dtype=params_dtype,
+            ),
             storage_format_cls=self.storage_format_cls,
             # if we don't support F.linear or something analogous,
             # transpose when we compress so we can use a basic matmul
-            compress_transposed=not supports_linear)
+            compress_transposed=not supports_linear,
+        )
 
         set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
 
@@ -58,24 +70,28 @@ class SparseW16A16LinearMethod(LinearMethodBase):
             assert not w.has_compressed_data
             output = F.linear(x, w.uncompressed_data, bias)
         elif self.storage_format_cls == SparseSemiStructuredStorageFormat:
-            assert bias is None
             w_encap = w.compressed_data.encapsulated_torch_sparse_tensor
-            out_shape = (x.shape[:-1] + (w_encap.shape[0], ))
+            out_shape = x.shape[:-1] + (w_encap.shape[0],)
             reshaped_x, valid_rows_range = pad_tensor_to_multiple(
-                x.reshape(-1, x.shape[-1]), 8)
+                x.reshape(-1, x.shape[-1]), 8
+            )
             output = F.linear(
-                reshaped_x, w_encap,
-                torch.nn.Parameter(torch.zeros((w_encap.shape[0], ))).to(
-                    reshaped_x.dtype).to(reshaped_x.device)).contiguous()
-            output = extract_valid_rows(output, valid_rows_range)
-            return output.reshape(out_shape)
+                reshaped_x,
+                w_encap,
+                torch.nn.Parameter(torch.zeros((w_encap.shape[0],)))
+                .to(reshaped_x.dtype)
+                .to(reshaped_x.device),
+            ).contiguous()
+            output = extract_valid_rows(output, valid_rows_range).reshape(out_shape)
+            if bias is not None:
+                output = output + bias
         elif self.storage_format_cls == SparseBEGemmStorageFormat:
-            assert bias is None
             assert w.compress_transposed
-            out_shape = (x.shape[:-1] + (w.shape[0], ))
+            out_shape = x.shape[:-1] + (w.shape[0],)
             reshaped_x = x.reshape(-1, x.shape[-1])
-            y = be_ds_gemm(reshaped_x, w.compressed_data)
-            return y.reshape(out_shape)
+            output = be_ds_gemm(reshaped_x, w.compressed_data).reshape(out_shape)
+            if bias is not None:
+                output = output + bias
         else:
             # Standard matrix multiply
             # Uncompress to dense


### PR DESCRIPTION
Tested both unstructured and semi_structured - opt-125m has a bias which previous would assert:
```
  File "neuralmagic-vllm/vllm/model_executor/layers/sparsity/sparse_w16a16_linear_method.py", line 73, in apply_weights
    assert bias is None
```

```python
from vllm import LLM, SamplingParams

model = LLM(
    "nm-testing/opt-125m-pruned2.4",
    sparsity="semi_structured_sparse_w16a16",
    enforce_eager=True,
)

sampling_params = SamplingParams(max_tokens=10, temperature=0)
outputs = model.generate("Hi", sampling_params=sampling_params)
print(outputs[0].outputs[0].text)
```

```python
from vllm import LLM, SamplingParams

model = LLM(
    "nm-testing/opt-125m-pruned2.4",
    sparsity="sparse_w16a16",
    enforce_eager=True,
)

sampling_params = SamplingParams(max_tokens=10, temperature=0)
outputs = model.generate("Hi", sampling_params=sampling_params)
print(outputs[0].outputs[0].text)
```