### PR TITLE
Use naive decompress for SM<8.0

### DIFF
--- a/vllm/model_executor/layers/sparsity/sparse_w16a16.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16.py
@@ -6,7 +6,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.sparsity.base_config import SparsityConfig
 
 from .sparse_w16a16_linear_method import SparseW16A16LinearMethod
-from magic_wand import (CompressedStorageFormat, SparseBitmaskStorageFormat, 
+from magic_wand import (CompressedStorageFormat, SparseBitmaskStorageFormat,
                         SparseBEGemmStorageFormat)
 
 logger = init_logger(__name__)

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16.py
@@ -16,7 +16,6 @@ class SparseW16A16Config(SparsityConfig):
     """Config class for SparseW16A16."""
 
     def __init__(self) -> None:
-        # TODO: Add new configs here
         pass
 
     def __repr__(self) -> str:
@@ -44,7 +43,6 @@ class SparseW16A16Config(SparsityConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        # TODO: Update after checks on more GPUs
         return 70
 
     @classmethod

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16.py
@@ -25,7 +25,7 @@ class SparseW16A16Config(SparsityConfig):
     @classmethod
     def get_storage_format_cls(cls) -> Type[CompressedStorageFormat]:
         cuda_compute_capability = torch.cuda.get_device_capability()
-        if cuda_compute_capability > (8, 0):
+        if cuda_compute_capability >= (8, 0):
             return SparseBEGemmStorageFormat
         else:
             # For NVIDIA SM < 8.0

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16.py
@@ -2,17 +2,18 @@ from typing import Any, Dict, List, Type
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.model_executor.layers.sparsity.base_config import SparsityConfig
 
 from .sparse_w16a16_linear_method import SparseW16A16LinearMethod
-from magic_wand import (CompressedStorageFormat, SparseBEGemmStorageFormat)
+from magic_wand import (CompressedStorageFormat, SparseBitmaskStorageFormat, 
+                        SparseBEGemmStorageFormat)
+
+logger = init_logger(__name__)
 
 
 class SparseW16A16Config(SparsityConfig):
-    """Config class for SparseW16A16.
-
-    TODO: Add based on need
-    """
+    """Config class for SparseW16A16."""
 
     def __init__(self) -> None:
         # TODO: Add new configs here
@@ -23,7 +24,15 @@ class SparseW16A16Config(SparsityConfig):
 
     @classmethod
     def get_storage_format_cls(cls) -> Type[CompressedStorageFormat]:
-        return SparseBEGemmStorageFormat
+        cuda_compute_capability = torch.cuda.get_device_capability()
+        if cuda_compute_capability > (8, 0):
+            return SparseBEGemmStorageFormat
+        else:
+            # For NVIDIA SM < 8.0
+            logger.warning(f"Unstructured sparse kernels are not optimized for "
+                            "NVIDIA SM < 8.0. Naive decompress kernels will be "
+                            "used and can be slower than dense models")
+            return SparseBitmaskStorageFormat
 
     @classmethod
     def get_name(cls) -> str:
@@ -36,7 +45,7 @@ class SparseW16A16Config(SparsityConfig):
     @classmethod
     def get_min_capability(cls) -> int:
         # TODO: Update after checks on more GPUs
-        return 80
+        return 70
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:

--- a/vllm/model_executor/layers/sparsity/sparse_w16a16.py
+++ b/vllm/model_executor/layers/sparsity/sparse_w16a16.py
@@ -29,9 +29,9 @@ class SparseW16A16Config(SparsityConfig):
             return SparseBEGemmStorageFormat
         else:
             # For NVIDIA SM < 8.0
-            logger.warning(f"Unstructured sparse kernels are not optimized for "
-                            "NVIDIA SM < 8.0. Naive decompress kernels will be "
-                            "used and can be slower than dense models")
+            logger.warning("Unstructured sparse kernels are not optimized for "
+                           "NVIDIA SM < 8.0. Naive decompress kernels will be "
+                           "used and can be slower than dense models")
             return SparseBitmaskStorageFormat
 
     @classmethod


### PR DESCRIPTION
A warning will be printed out if this case is triggered:
```
WARNING 02-20 22:21:27 sparse_w16a16.py:32] Unstructured sparse kernels are not optimized for NVIDIA SM < 8.0. Naive decompress kernels will be used and can be slower than dense models
```

Works on a T4 with:
```python
from vllm import LLM, SamplingParams

model = LLM(
    "nm-testing/opt-125m-pruned2.4", 
    sparsity="sparse_w16a16",
    enforce_eager=True,
    dtype="float16",
)

sampling_params = SamplingParams(max_tokens=100, temperature=0)
outputs = model.generate("Hello my name is", sampling_params=sampling_params)
outputs[0].outputs[0].text
```

Test within colab: https://colab.research.google.com/drive/15xRvWX5gNaTb00BcaXhxwMm6yxavIKGN?usp=sharing
