### PR TITLE
Only import magic_wand if sparsity is enabled

### DIFF
--- a/vllm/model_executor/layers/parameters/lazy_compressed.py
+++ b/vllm/model_executor/layers/parameters/lazy_compressed.py
@@ -3,7 +3,6 @@ import torch
 from torch.utils._pytree import tree_map
 
 from typing import Type
-from magic_wand import (CompressedStorageFormat, SparseBitmaskStorageFormat)
 
 
 class LazyCompressedParameter(torch.Tensor):
@@ -12,7 +11,7 @@ class LazyCompressedParameter(torch.Tensor):
     def __new__(cls,
                 uncompressed_data: torch.Tensor,
                 storage_format_cls: Type[
-                    CompressedStorageFormat] = SparseBitmaskStorageFormat,
+                    "CompressedStorageFormat"] = "SparseBitmaskStorageFormat",
                 compress_transposed: bool = False):
         self = torch.Tensor._make_wrapper_subclass(
             cls,

--- a/vllm/model_executor/layers/parameters/lazy_compressed.py
+++ b/vllm/model_executor/layers/parameters/lazy_compressed.py
@@ -7,12 +7,9 @@ from typing import Type
 
 is_magic_wand_available = importlib.util.find_spec("magic_wand") is not None
 
-if is_magic_wand_available:
-    from magic_wand import (CompressedStorageFormat,
-                            SparseBitmaskStorageFormat)
-else:
-    CompressedStorageFormat = "CompressedStorageFormat"
-    SparseBitmaskStorageFormat = "SparseBitmaskStorageFormat"
+# These are types from magic_wand, but we only want to import if required
+CompressedStorageFormat = "CompressedStorageFormat"
+SparseBitmaskStorageFormat = "SparseBitmaskStorageFormat"
 
 
 class LazyCompressedParameter(torch.Tensor):
@@ -24,7 +21,7 @@ class LazyCompressedParameter(torch.Tensor):
                     CompressedStorageFormat] = SparseBitmaskStorageFormat,
                 compress_transposed: bool = False):
 
-        if not is_magic_wand_available():
+        if not is_magic_wand_available:
             raise ValueError(
                 "magic_wand is not available and required for sparsity "
                 "support. Please install it with `pip install magic_wand`")

--- a/vllm/model_executor/layers/sparsity/__init__.py
+++ b/vllm/model_executor/layers/sparsity/__init__.py
@@ -1,8 +1,15 @@
 from typing import Type
+import importlib.util
 
-from vllm.model_executor.layers.sparsity.base_config import SparsityConfig
-from vllm.model_executor.layers.sparsity.sparse_w16a16 import SparseW16A16Config
-from vllm.model_executor.layers.sparsity.semi_structured_sparse_w16a16 import SemiStructuredSparseW16A16Config
+is_magic_wand_available = importlib.util.find_spec("magic_wand") is not None
+if importlib.util.find_spec("magic_wand") is None:
+    raise ValueError(
+        "magic_wand is not available and required for sparsity "
+        "support. Please install it with `pip install magic_wand`")
+
+from vllm.model_executor.layers.sparsity.base_config import SparsityConfig  # noqa: E402
+from vllm.model_executor.layers.sparsity.sparse_w16a16 import SparseW16A16Config  # noqa: E402
+from vllm.model_executor.layers.sparsity.semi_structured_sparse_w16a16 import SemiStructuredSparseW16A16Config  # noqa: E402
 
 _SPARSITY_CONFIG_REGISTRY = {
     "sparse_w16a16": SparseW16A16Config,

--- a/vllm/model_executor/layers/sparsity/__init__.py
+++ b/vllm/model_executor/layers/sparsity/__init__.py
@@ -2,7 +2,7 @@ from typing import Type
 import importlib.util
 
 is_magic_wand_available = importlib.util.find_spec("magic_wand") is not None
-if importlib.util.find_spec("magic_wand") is None:
+if not is_magic_wand_available:
     raise ValueError(
         "magic_wand is not available and required for sparsity "
         "support. Please install it with `pip install magic_wand`")

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -17,8 +17,6 @@ from tqdm.auto import tqdm
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import (get_quantization_config,
                                                      QuantizationConfig)
-from vllm.model_executor.layers.sparsity import (get_sparsity_config,
-                                                 SparsityConfig)
 from vllm.model_executor.layers.parameters import LazyCompressedParameter
 
 logger = init_logger(__name__)
@@ -91,7 +89,8 @@ def get_sparse_config(
     model_name_or_path: str,
     hf_config: PretrainedConfig,
     cache_dir: Optional[str] = None,
-) -> SparsityConfig:
+) -> "SparsityConfig":
+    from vllm.model_executor.layers.sparsity import get_sparsity_config
     sparsity_cls = get_sparsity_config(sparsity)
     hf_sparsity_config = getattr(hf_config, "sparsity_config", None)
     if hf_sparsity_config is not None:

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -89,7 +89,7 @@ def get_sparse_config(
     model_name_or_path: str,
     hf_config: PretrainedConfig,
     cache_dir: Optional[str] = None,
-) -> "SparsityConfig":
+):
     from vllm.model_executor.layers.sparsity import get_sparsity_config
     sparsity_cls = get_sparsity_config(sparsity)
     hf_sparsity_config = getattr(hf_config, "sparsity_config", None)


### PR DESCRIPTION
Tested by making sure magic_wand was uninstalled and this code for a dense model runs fine:
```python
from vllm import LLM, SamplingParams
model = LLM("nm-testing/opt-125m-pruned2.4", enforce_eager=True)
```

Then testing with a sparse model run:
```python
from vllm import LLM, SamplingParams
model = LLM("nm-testing/opt-125m-pruned2.4", sparsity="sparse_w16a16", enforce_eager=True)
```
output:
```
...
  File "/home/michael/code/neuralmagic-vllm/vllm/model_executor/weight_utils.py", line 93, in get_sparse_config
    from vllm.model_executor.layers.sparsity import get_sparsity_config
  File "/home/michael/code/neuralmagic-vllm/vllm/model_executor/layers/sparsity/__init__.py", line 6, in <module>
    raise ValueError(
ValueError: magic_wand is not available and required for sparsity support. Please install it with `pip install magic_wand`
```