### PR TITLE
Update arg_utils.py with `semi_structured_sparse_w16a16`

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -202,7 +202,7 @@ class EngineArgs:
             '--sparsity',
             '-s',
             type=str,
-            choices=['sparse_w16a16', None],
+            choices=[None, 'sparse_w16a16', 'semi_structured_sparse_w16a16'],
             default=None,
             help='Method used to compress sparse weights. If '
             'None, we first check the `sparsity_config` attribute '


### PR DESCRIPTION
Tested by checking the help message in openai server:
```
python -m vllm.entrypoints.openai.api_server --help
```

Before:
```
  --sparsity {sparse_w16a16,None}, -s {sparse_w16a16,None}
                        Method used to compress sparse weights. If None, we first check the `sparsity_config`
                        attribute in the model config file. If that is None we assume the model weights are dense
 ```
 
 After:
```
  --sparsity {None,sparse_w16a16,semi_structured_sparse_w16a16}, -s {None,sparse_w16a16,semi_structured_sparse_w16a16}
                        Method used to compress sparse weights. If None, we first check the `sparsity_config`
                        attribute in the model config file. If that is None we assume the model weights are dense
```