### PR TITLE
additions for bump to v0.3.2

### DIFF
--- a/.github/actions/nm-set-env/action.yml
+++ b/.github/actions/nm-set-env/action.yml
@@ -15,6 +15,7 @@ runs:
       NUM_THREADS=$(./.github/scripts/determine-threading -G ${{ inputs.Gi_per_thread }})
       echo "MAX_JOBS=${NUM_THREADS}" >> $GITHUB_ENV
       echo "VLLM_INSTALL_PUNICA_KERNELS=1" >> $GITHUB_ENV
+      echo "NCCL_IGNORE_DISABLED_P2P=1" >> $GITHUB_ENV
       echo "PYENV_ROOT=/usr/local/apps/pyenv" >> $GITHUB_ENV
       echo "XDG_CONFIG_HOME=/usr/local/apps" >> $GITHUB_ENV
       WHOAMI=$(whoami)

--- a/.github/scripts/run-tests
+++ b/.github/scripts/run-tests
@@ -48,7 +48,7 @@ if [ ! -d "${TEST_DIR}" ]; then
 fi
 
 # run tests serially
-TESTS_DOT_PY=$(find ${TEST_DIR}  -not -name "__init__.py" -name "*.py")
+TESTS_DOT_PY=$(find ${TEST_DIR}  -not -name "__init__.py" -name "test*.py")
 TESTS_TO_RUN=($TESTS_DOT_PY)
 SUCCESS=0
 for TEST in "${TESTS_TO_RUN[@]}"

--- a/.github/scripts/run-tests
+++ b/.github/scripts/run-tests
@@ -55,7 +55,7 @@ for TEST in "${TESTS_TO_RUN[@]}"
 do
     LOCAL_SUCCESS=0
     RESULT_XML=$(echo ${TEST} | sed -e "s/${TEST_DIR}/${RESULTS_DIR}/" | sed -e "s/.py/.xml/")
-    pytest --forked --junitxml=${RESULT_XML} ${TEST} || LOCAL_SUCCESS=$?
+    pytest --junitxml=${RESULT_XML} ${TEST} || LOCAL_SUCCESS=$?
     SUCCESS=$((SUCCESS + LOCAL_SUCCESS))
 done
 

--- a/.github/scripts/run-tests
+++ b/.github/scripts/run-tests
@@ -48,7 +48,7 @@ if [ ! -d "${TEST_DIR}" ]; then
 fi
 
 # run tests serially
-TESTS_DOT_PY=$(find ${TEST_DIR}  -not -name "__init__.py" -name "test*.py")
+TESTS_DOT_PY=$(find ${TEST_DIR} -name "test*.py")
 TESTS_TO_RUN=($TESTS_DOT_PY)
 SUCCESS=0
 for TEST in "${TESTS_TO_RUN[@]}"

--- a/.github/scripts/run-tests
+++ b/.github/scripts/run-tests
@@ -55,7 +55,7 @@ for TEST in "${TESTS_TO_RUN[@]}"
 do
     LOCAL_SUCCESS=0
     RESULT_XML=$(echo ${TEST} | sed -e "s/${TEST_DIR}/${RESULTS_DIR}/" | sed -e "s/.py/.xml/")
-    pytest --junitxml=${RESULT_XML} ${TEST} || LOCAL_SUCCESS=$?
+    pytest --forked --junitxml=${RESULT_XML} ${TEST} || LOCAL_SUCCESS=$?
     SUCCESS=$((SUCCESS + LOCAL_SUCCESS))
 done
 

--- a/.github/workflows/remote-push.yml
+++ b/.github/workflows/remote-push.yml
@@ -15,13 +15,13 @@ jobs:
     #       matured.
 
     # TODO: enable this later
-    AWS-AVX2-32G-A10G-24G:
+    AWS-AVX2-192G-4-A10G-96G:
         strategy:
             matrix:
                 python: [3.10.12]
         uses: ./.github/workflows/build-test.yml
         with:
-            label: aws-avx2-32G-a10g-24G
+            label: aws-avx2-192G-4-a10g-96G
             timeout: 180
             gitref: '${{ github.ref }}'
             Gi_per_thread: 4

--- a/.github/workflows/remote-push.yml
+++ b/.github/workflows/remote-push.yml
@@ -11,10 +11,9 @@ concurrency:
 
 jobs:
 
-    # TODO: expand python matrix later, once CI system has
-    #       matured.
+    # TODO: expand python matrix later, once CI system has matured.
 
-    # TODO: enable this later
+    # multi-gpu
     AWS-AVX2-192G-4-A10G-96G:
         strategy:
             matrix:
@@ -22,6 +21,20 @@ jobs:
         uses: ./.github/workflows/build-test.yml
         with:
             label: aws-avx2-192G-4-a10g-96G
+            timeout: 180
+            gitref: '${{ github.ref }}'
+            Gi_per_thread: 4
+            python: ${{ matrix.python }}
+        secrets: inherit
+
+    # single gpu
+    AWS-AVX2-32G-A10G-24G:
+        strategy:
+            matrix:
+                python: [3.11.4]
+        uses: ./.github/workflows/build-test.yml
+        with:
+            label: aws-avx2-32G-a10g-24G
             timeout: 180
             gitref: '${{ github.ref }}'
             Gi_per_thread: 4

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -5,9 +5,10 @@ Run `pytest tests/distributed/test_basic_distributed_correctness.py --forked`.
 import pytest
 import torch
 
+
 MODELS = [
     "facebook/opt-125m",
-    "meta-llama/Llama-2-7b-hf",
+    # "meta-llama/Llama-2-7b-hf",
 ]
 
 

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -6,9 +6,10 @@ import pytest
 import torch
 
 
+# TODO: just picking one, need to update test runner to selectively use "--forked"
 MODELS = [
     "facebook/opt-125m",
-    "meta-llama/Llama-2-7b-hf",
+    # "meta-llama/Llama-2-7b-hf",
 ]
 
 

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -18,7 +18,7 @@ MODELS = [
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [5])
-def test_models1(
+def test_models(
     hf_runner,
     vllm_runner,
     example_prompts,

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -8,7 +8,7 @@ import torch
 
 MODELS = [
     "facebook/opt-125m",
-    # "meta-llama/Llama-2-7b-hf",
+    "meta-llama/Llama-2-7b-hf",
 ]
 
 
@@ -17,7 +17,7 @@ MODELS = [
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [5])
-def test_models(
+def test_models1(
     hf_runner,
     vllm_runner,
     example_prompts,

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -62,7 +62,7 @@ def zephyr_lora_files():
 
 @pytest.fixture(scope="session")
 def server(zephyr_lora_files):
-    ray.init()
+    ray.init(ignore_reinit_error=True)
     server_runner = ServerRunner.remote([
         "--model",
         MODEL_NAME,

--- a/vllm/test_utils.py
+++ b/vllm/test_utils.py
@@ -28,7 +28,7 @@ def multi_process_tensor_parallel(
 ) -> None:
     # Using ray helps debugging the error when it failed
     # as compared to multiprocessing.
-    ray.init()
+    ray.init(ignore_reinit_error=True)
 
     distributed_init_port = get_open_port()
     refs = []


### PR DESCRIPTION
SUMMARY:
* "remote push" job for multi-gpu runner.
* "remote push" job for single gpu runner.
* patches for re-initialization of "ray". found other places in `vllm` where they are passing in `ignore_reinit_error=True`, it just looked like they missed a couple of places.
* patch "find" command to only find *.py files starting with "test_".


TEST PLAN:
runs on remote push
