### PR TITLE
Loudly reject compression when the tensor isn't sparse enough

### DIFF
--- a/vllm/model_executor/layers/parameters/lazy_compressed.py
+++ b/vllm/model_executor/layers/parameters/lazy_compressed.py
@@ -5,6 +5,10 @@ import importlib.util
 
 from typing import Type
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 is_magic_wand_available = importlib.util.find_spec("magic_wand") is not None
 
 # These are types from magic_wand, but we only want to import if required
@@ -91,13 +95,37 @@ class LazyCompressedParameter(torch.Tensor):
         return rs
 
     def compress(self) -> None:
-        density = torch.count_nonzero(
-            self.uncompressed_data).item() / numpy.prod(self.shape)
+        from magic_wand import SparseSemiStructuredStorageFormat
 
-        # only compress if we have sufficient sparsity (>=45%), currently
-        # this applies globally across all formats including 2:4
-        if (1 - density) < 0.45:
-            return
+        if self.storage_format_cls == SparseSemiStructuredStorageFormat:
+            # Semi-structured sparsity assumes a 2:4 pattern, where each 4 elements
+            # have at minimum 2 zeros. We need to validate this pattern exists, so
+            # we check the whole tensor before committing to compression.
+
+            # Count zeros in each group of 4
+            reshaped_tensor = self.uncompressed_data.view(-1, 4)
+            zeros = reshaped_tensor == 0
+            zeros_per_group = zeros.sum(dim=1)
+
+            # Check if each group has exactly 2 zeros
+            has_semi_structured_sparsity = torch.all(zeros_per_group == 2)
+
+            if not has_semi_structured_sparsity:
+                logger.warning(
+                    f"Called compress() on tensor of shape {self.shape} but does not "
+                    "have 2:4 sparsity, skipping compression")
+                return
+
+        else:
+            sparsity = 1 - (torch.count_nonzero(self.uncompressed_data).item()
+                            / numpy.prod(self.shape))
+
+            # Only compress if we have sufficient sparsity (>=45%)
+            if sparsity < 0.45:
+                logger.warning(
+                    f"Called compress() on tensor of shape {self.shape} but only has "
+                    f"{sparsity}% sparsity, skipping compression")
+                return
 
         if self.uncompressed_data is None:
             raise ValueError(

--- a/vllm/model_executor/layers/parameters/lazy_compressed.py
+++ b/vllm/model_executor/layers/parameters/lazy_compressed.py
@@ -124,7 +124,7 @@ class LazyCompressedParameter(torch.Tensor):
             if sparsity < 0.45:
                 logger.warning(
                     f"Called compress() on tensor of shape {self.shape} but only has "
-                    f"{sparsity}% sparsity, skipping compression")
+                    f"{sparsity:.2}% sparsity, skipping compression")
                 return
 
         if self.uncompressed_data is None:


### PR DESCRIPTION
Tested by trying to enable 2:4 sparsity on a dense model:
```python
from vllm import LLM

model = LLM(
    "facebook/opt-125m",
    sparsity="semi_structured_sparse_w16a16",
)
```

Output:
```
python compress-vllm.py 
INFO 02-23 23:10:00 llm_engine.py:79] Initializing an LLM engine with config: model='facebook/opt-125m', tokenizer='facebook/opt-125m', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=512, download_dir=None, load_format=auto, tensor_parallel_size=1, disable_custom_all_reduce=False, quantization=None, sparsity=semi_structured_sparse_w16a16, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, seed=0)
INFO 02-23 23:10:04 weight_utils.py:176] Using model weights format ['*.bin']
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([2304, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([3072, 768]) but does not have 2:4 sparsity, skipping compression
WARNING 02-23 23:10:04 lazy_compressed.py:114] Called compress() on tensor of shape torch.Size([768, 3072]) but does not have 2:4 sparsity, skipping compression
INFO 02-23 23:10:05 llm_engine.py:338] # GPU blocks: 76243, # CPU blocks: 7281
INFO 02-23 23:10:07 model_runner.py:676] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
INFO 02-23 23:10:07 model_runner.py:680] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
INFO 02-23 23:10:09 model_runner.py:748] Graph capturing finished in 2 secs.
```
